### PR TITLE
QA-13749: flush user cache and membership cache for the user to updat…

### DIFF
--- a/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
+++ b/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
@@ -93,7 +93,6 @@ import javax.naming.ldap.Rdn;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jahia.registries.ServicesRegistry;
-import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRTemplate;
 import org.springframework.ldap.filter.AndFilter;
@@ -403,11 +402,11 @@ public class LDAPUserGroupProvider extends BaseUserGroupProvider {
                         ldapCacheManager.clearUserCacheEntryByName(providerKey, userName);
                         return Boolean.TRUE;
                     });
-                } catch (RepositoryException ex) {
+                } catch (Exception ex) {
                     logger.warn("Impossible to flush membership cache for {}", userName, ex);
+                } finally {
+                    return true;
                 }
-
-                return true;
             }
         } catch (NamingException | org.springframework.ldap.NamingException e) {
             // Context creation failed - authentication did not succeed

--- a/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
+++ b/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
@@ -393,7 +393,13 @@ public class LDAPUserGroupProvider extends BaseUserGroupProvider {
                     JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> {
                         final String userRelativePath = ServicesRegistry.getInstance().getJahiaUserManagerService().getUserSplittingRule().getRelativePathForUsername(userName);
                         final String providerKey = getKey();
-                        JahiaGroupManagerService.getInstance().flushMembershipCache("/users/providers/" + providerKey + userRelativePath, session);
+                        final String siteKey = getSiteKey();
+                        final StringBuilder memberPath = new StringBuilder();
+                        if (siteKey != null) {
+                            memberPath.append("/sites/").append(siteKey);
+                        }
+                        memberPath.append("/users/providers/").append(providerKey).append(userRelativePath);
+                        JahiaGroupManagerService.getInstance().flushMembershipCache(memberPath.toString(), session);
                         ldapCacheManager.clearUserCacheEntryByName(providerKey, userName);
                         return Boolean.TRUE;
                     });


### PR DESCRIPTION
…e membership on login

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13749

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance ==> as we're flushing the cache in login, it might have an impact. The addition of a property at the provider level to activate the flush on login or not could be a solution to mitigate the issue if there is one.
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
