### PR TITLE
QA-14480: Make LDAP cache configs inherit from jahia default cache co…

### DIFF
--- a/src/main/java/org/jahia/services/usermanager/ldap/cache/LDAPCacheManager.java
+++ b/src/main/java/org/jahia/services/usermanager/ldap/cache/LDAPCacheManager.java
@@ -75,10 +75,12 @@ public class LDAPCacheManager {
     }
 
     private Ehcache createLDAPCache(CacheManager cacheManager, String cacheName) {
-        CacheConfiguration cacheConfiguration = new CacheConfiguration();
+        CacheConfiguration cacheConfiguration = cacheManager.getConfiguration().getDefaultCacheConfiguration() != null ?
+                cacheManager.getConfiguration().getDefaultCacheConfiguration().clone() :
+                new CacheConfiguration();
         cacheConfiguration.setName(cacheName);
-        cacheConfiguration.setTimeToIdleSeconds(3600);
         cacheConfiguration.setEternal(false);
+        cacheConfiguration.setTimeToIdleSeconds(3600);
         // Create a new cache with the configuration
         Ehcache cache = new Cache(cacheConfiguration);
         cache.setName(cacheName);


### PR DESCRIPTION
…nfig, to able to benefit from removal cluster sync (jgroup cache EHCache listener)

https://jira.jahia.org/browse/QA-14480