### PR TITLE
TECH-1416: Upgrade Guava or stop exposing it from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,16 +116,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgs combine.children="append">
-                        <arg>--add-exports</arg>
-                        <arg>java.naming/com.sun.jndi.ldap=ALL-UNNAMED</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.0.0</version>
+        <version>8.2.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <artifactId>ldap</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,24 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>--add-exports</arg>
+                        <arg>java.naming/com.sun.jndi.ldap=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.1.0.0</version>
         <relativePath />
     </parent>
     <artifactId>ldap</artifactId>
@@ -40,20 +40,6 @@
         <embed-dependency>*;groupId=org.springframework.ldap|org.springframework.data|commons-pool;scope=compile; type=!pom; inline=false</embed-dependency>
         <jahia-module-type>system</jahia-module-type>
         <jahia-depends>default,external-provider-users-groups</jahia-depends>
-        <import-package>
-            org.jahia.modules.external.users,
-            org.springframework.beans;version="[3.2,4)";resolution:=optional,
-            org.springframework.beans.factory;version="[3.2,4)";resolution:=optional,
-            org.springframework.beans.factory.xml;version="[3.2,4)";resolution:=optional,
-            org.springframework.beans.factory.config;version="[3.2,4)";resolution:=optional,
-            org.springframework.beans.factory.parsing;version="[3.2,4)";resolution:=optional,
-            org.springframework.beans.factory.support;version="[3.2,4)";resolution:=optional,
-            org.springframework.transaction;version="[3.2,4)";resolution:=optional,
-            org.springframework.transaction.support;version="[3.2,4)";resolution:=optional,
-            org.springframework.orm.hibernate5;version="[3.2,4)";resolution:=optional,
-            org.springframework.dao;version="[3.2,4)";resolution:=optional
-        </import-package>
-        <jahia-module-signature>MCwCFCbEjooYjZShbBXBcZECla/lN+WbAhRaHjyMGEkT3s67dIwtuqkH7yNEaA==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFCbEjooYjZShbBXBcZECla/lN+WbAhRaHjyMGEkT3s67dIwtuqkH7yNEaA==</jahia-module-signature>
     </properties>
@@ -126,11 +112,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -150,7 +131,27 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <!--
+                            com.google.common extends range
+                            Jahia 8.1.0.0 exposes Guave 30.1.x
+                            Jahia 8.2.0.0 use a Guava Bundle in version 33.x
+                        -->
                         <_dsannotations>*</_dsannotations>
+                        <Import-Package>
+                            org.jahia.modules.external.users,
+                            org.springframework.beans;version="[3.2,4)";resolution:=optional,
+                            org.springframework.beans.factory;version="[3.2,4)";resolution:=optional,
+                            org.springframework.beans.factory.xml;version="[3.2,4)";resolution:=optional,
+                            org.springframework.beans.factory.config;version="[3.2,4)";resolution:=optional,
+                            org.springframework.beans.factory.parsing;version="[3.2,4)";resolution:=optional,
+                            org.springframework.beans.factory.support;version="[3.2,4)";resolution:=optional,
+                            org.springframework.transaction;version="[3.2,4)";resolution:=optional,
+                            org.springframework.transaction.support;version="[3.2,4)";resolution:=optional,
+                            org.springframework.orm.hibernate5;version="[3.2,4)";resolution:=optional,
+                            org.springframework.dao;version="[3.2,4)";resolution:=optional,
+                            com.google.common.base;version="[30.1,34)",
+                            com.google.common.collect;version="[30.1,34)"
+                        </Import-Package>
                         <_exportcontents>org.jahia.services.usermanager.ldap, org.jahia.services.usermanager.ldap.*, org.springframework.ldap.core;version=2.3.4.RELEASE</_exportcontents>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1416

## Description

Update jahia modules dependency add explicit use of guava in dependencies and fix java11 compilation problem due to module visiblity

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation