### PR TITLE
BACKLOG-21147: Update jahia.plugin.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     </scm>
 
     <properties>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
         <embed-dependency>*;groupId=org.springframework.ldap|org.springframework.data|commons-pool;scope=compile; type=!pom; inline=false</embed-dependency>
         <jahia-module-type>system</jahia-module-type>
         <jahia-depends>default,external-provider-users-groups</jahia-depends>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21147

## Description

Issue with dry run for releasing ldap-provider https://github.com/Jahia/JahiaReleaseTool/actions/runs/8638931540/job/23685202988#step:8:22191

```
Error: [ERROR] Failed to execute goal org.jahia.server:jahia-maven-plugin:5.18:dependencies (prepare-package-dependencies) on project ldap: Execution prepare-package-dependencies of goal org.jahia.server:jahia-maven-plugin:5.18:dependencies failed: A required class was missing while executing org.jahia.server:jahia-maven-plugin:5.18:dependencies: org/jahia/utils/osgi/parsers/ParsingContext
```

Update jahia.plugin.version to 6.9