### PR TITLE
BACKLOG-21147 : set transitive import package as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
                             org.springframework.transaction.support;version="[3.2,4)";resolution:=optional,
                             org.springframework.orm.hibernate5;version="[3.2,4)";resolution:=optional,
                             org.springframework.dao;version="[3.2,4)";resolution:=optional,
+                            org.springframework.jdbc.datasource;version="[3.2,4)";resolution:=optional,
                             com.google.common.base;version="[30.1,34)",
                             com.google.common.collect;version="[30.1,34)",
                             *


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-21147

The new version of maven jahia plugin requires to set optional export package explicitly. 