### PR TITLE
fix: use typed equality filter for dynamic group membership lookup

### DIFF
--- a/.chachalog/V8QkXzr6.md
+++ b/.chachalog/V8QkXzr6.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+LDAP-provider: minor
+---
+
+Hardened resolution of LDAP dynamic group memberships.

--- a/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
+++ b/src/main/java/org/jahia/services/usermanager/ldap/LDAPUserGroupProvider.java
@@ -65,6 +65,7 @@ import javax.naming.ldap.Rdn;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.ldap.filter.AndFilter;
+import org.springframework.ldap.filter.EqualsFilter;
 import org.springframework.ldap.filter.HardcodedFilter;
 
 import static org.springframework.ldap.query.LdapQueryBuilder.query;
@@ -196,7 +197,9 @@ public class LDAPUserGroupProvider extends BaseUserGroupProvider {
                     final String ldapFilter = ldapURL.getFilter();
                     final Filter dynamicFilter = (new AndFilter())
                             .and(new HardcodedFilter(ldapFilter))
-                            .and(new HardcodedFilter(String.format("(%s=%s)", userConfig.getUidSearchAttribute(), userId)));
+                            // build the identifier clause with EqualsFilter so the value is escaped
+                            // consistently with the module's other typed LDAP queries
+                            .and(new EqualsFilter(userConfig.getUidSearchAttribute(), userId));
                     final String url = dynamicMembersURL.replace(ldapFilter, dynamicFilter.toString());
 
                     members.addAll(loadMembersFromUrl(url));


### PR DESCRIPTION
### What

`isDynamicGroupMembers()` builds the dynamic-group membership query by manually formatting the user-identifier clause into a `HardcodedFilter`:

```java
.and(new HardcodedFilter(String.format("(%s=%s)",
        userConfig.getUidSearchAttribute(), userId)))
```

`HardcodedFilter` passes its string through verbatim, so the identifier is not escaped the way the rest of the module's queries are. The other query paths already use typed filters (`.where(attr).is(value)`), which encode their values consistently.

### Change

Use `EqualsFilter` for the identifier clause so the value is escaped the same way as everywhere else in the module:

```diff
-    .and(new HardcodedFilter(String.format("(%s=%s)", userConfig.getUidSearchAttribute(), userId)));
+    .and(new EqualsFilter(userConfig.getUidSearchAttribute(), userId));
```

One-line change plus the import and a changelog note. `mvn compile` passes. No behaviour change for well-formed identifiers.
